### PR TITLE
Fix issue of not defined 'logger'

### DIFF
--- a/pythonx/ncm2_tagprefix.py
+++ b/pythonx/ncm2_tagprefix.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import vim
-from ncm2 import Ncm2Source
+from ncm2 import Ncm2Source, getLogger
 import re
 from os import path
 
+logger = getLogger(__name__)
 
 class Source(Ncm2Source):
 


### PR DESCRIPTION
Fix issue of missing name 'logger'.
`[ncm2_tagprefix@yarp] NameError: name 'logger' is not defined`